### PR TITLE
Phpstan update

### DIFF
--- a/Block/Adminhtml/Metadata.php
+++ b/Block/Adminhtml/Metadata.php
@@ -29,7 +29,7 @@ class Metadata extends Template
     /**
      * @return array<string, mixed>
      */
-    public function getMetadata(): array
+    public function getMetadata()
     {
         $storageIdentifier = $this->getStorageIdentifier();
         if ($storageIdentifier === null || $storageIdentifier === '') {

--- a/Block/Adminhtml/Metadata.php
+++ b/Block/Adminhtml/Metadata.php
@@ -13,6 +13,9 @@ class Metadata extends Template
 {
     private $metaStorage;
 
+    /**
+     * @param array<mixed> $data
+     */
     public function __construct(
         BackendBlockContext $context,
         MetaStorage $metaStorage,

--- a/Block/Adminhtml/Metadata.php
+++ b/Block/Adminhtml/Metadata.php
@@ -26,7 +26,10 @@ class Metadata extends Template
         $this->metaStorage = $metaStorage;
     }
 
-    public function getMetadata()
+    /**
+     * @return array<string, mixed>
+     */
+    public function getMetadata(): array
     {
         $storageIdentifier = $this->getStorageIdentifier();
         if ($storageIdentifier === null || $storageIdentifier === '') {

--- a/Block/Adminhtml/Metadata.php
+++ b/Block/Adminhtml/Metadata.php
@@ -36,6 +36,11 @@ class Metadata extends Template
         return $metaData;
     }
 
+    /**
+     * @param array<string, mixed> $metaData
+     *
+     * @return array<string, mixed>
+     */
     private function format(array $metaData): array
     {
         $formatted = [];

--- a/Checker/Catalog/Category/UrlPath.php
+++ b/Checker/Catalog/Category/UrlPath.php
@@ -26,7 +26,7 @@ class UrlPath
     private $categoryCollectionFactory;
     private $attributeScopeOverriddenValueFactory;
 
-    /** @var array */
+    /** @var array<string, string> */
     private $calculatedUrlPathPerCategoryAndStoreId;
 
     public function __construct(
@@ -39,6 +39,9 @@ class UrlPath
         $this->attributeScopeOverriddenValueFactory = $attributeScopeOverriddenValueFactory;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function execute(): array
     {
         $categoryData = $this->checkForIncorrectUrlPathAttributeValues();
@@ -46,6 +49,9 @@ class UrlPath
         return $categoryData;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function checkForIncorrectUrlPathAttributeValues(): array
     {
         $problems = [];
@@ -82,6 +88,9 @@ class UrlPath
         return $problems;
     }
 
+    /**
+     * @return CategoryCollection<Category>
+     */
     private function getAllVisibleCategoriesWithStoreId(int $storeId): CategoryCollection
     {
         $categories = $this->categoryCollectionFactory->create()
@@ -165,6 +174,9 @@ class UrlPath
         }
     }
 
+    /**
+     * @return array<string>
+     */
     private function getAllInvisibleRootIds(): array
     {
         $categoryIds = $this->categoryCollectionFactory->create()

--- a/Checker/Catalog/Category/UrlPath.php
+++ b/Checker/Catalog/Category/UrlPath.php
@@ -26,6 +26,7 @@ class UrlPath
     private $categoryCollectionFactory;
     private $attributeScopeOverriddenValueFactory;
 
+    /** @var array */
     private $calculatedUrlPathPerCategoryAndStoreId;
 
     public function __construct(
@@ -81,7 +82,7 @@ class UrlPath
         return $problems;
     }
 
-    private function getAllVisibleCategoriesWithStoreId($storeId): CategoryCollection
+    private function getAllVisibleCategoriesWithStoreId(int $storeId): CategoryCollection
     {
         $categories = $this->categoryCollectionFactory->create()
             ->addAttributeToSelect('name')

--- a/Checker/Catalog/Category/UrlPath.php
+++ b/Checker/Catalog/Category/UrlPath.php
@@ -142,9 +142,9 @@ class UrlPath
             foreach ($allCategories as $category) {
                 $categoryId = (int) $category->getId();
 
-                $path = $category->getPath();
+                $path = $category->getPath() ?: '';
                 foreach ($invisibleRootIds as $rootId) {
-                    $path = preg_replace('#^' . preg_quote($rootId) . self::URL_PATH_SEPARATOR . '#', '', $path);
+                    $path = preg_replace('#^' . preg_quote($rootId) . self::URL_PATH_SEPARATOR . '#', '', $path) ?: '';
                 }
 
                 $tempCatData[$categoryId] = [

--- a/Checker/Catalog/Product/UrlKey.php
+++ b/Checker/Catalog/Product/UrlKey.php
@@ -27,6 +27,9 @@ class UrlKey
         $this->progress = $progress;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function execute(): array
     {
         $productData = array_merge(

--- a/Checker/Catalog/Product/UrlKey/DuplicateUrlKey.php
+++ b/Checker/Catalog/Product/UrlKey/DuplicateUrlKey.php
@@ -9,6 +9,7 @@ use Baldwin\UrlDataIntegrityChecker\Console\Progress;
 use Baldwin\UrlDataIntegrityChecker\Util\Stores as StoresUtil;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Attribute\ScopeOverriddenValueFactory as AttributeScopeOverriddenValueFactory;
+use Magento\Catalog\Model\Product as ProductModel;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
 use Magento\Store\Model\Store;
@@ -43,6 +44,9 @@ class DuplicateUrlKey
         $this->cachedProductSkusByIds = [];
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function execute(): array
     {
         $this->cachedProductUrlKeyData = [];
@@ -53,6 +57,9 @@ class DuplicateUrlKey
         return $productData;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     private function checkForDuplicatedUrlKeyAttributeValues(): array
     {
         $this->progress->initProgressBar(
@@ -99,6 +106,9 @@ class DuplicateUrlKey
         return $productsWithProblems;
     }
 
+    /**
+     * @param ProductCollection<ProductModel> $collection
+     */
     private function storeProductUrlKeyData(int $storeId, ProductCollection $collection)
     {
         foreach ($collection as $product) {
@@ -125,6 +135,9 @@ class DuplicateUrlKey
         }
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     private function getProductsWithDuplicatedUrlKeyProblems(): array
     {
         $problems = [];

--- a/Checker/Catalog/Product/UrlKey/DuplicateUrlKey.php
+++ b/Checker/Catalog/Product/UrlKey/DuplicateUrlKey.php
@@ -37,6 +37,10 @@ class DuplicateUrlKey
         $this->progress = $progress;
         $this->productCollectionFactory = $productCollectionFactory;
         $this->attributeScopeOverriddenValueFactory = $attributeScopeOverriddenValueFactory;
+
+        $this->progressIndex = 0;
+        $this->cachedProductUrlKeyData = [];
+        $this->cachedProductSkusByIds = [];
     }
 
     public function execute(): array

--- a/Checker/Catalog/Product/UrlKey/EmptyUrlKey.php
+++ b/Checker/Catalog/Product/UrlKey/EmptyUrlKey.php
@@ -33,6 +33,8 @@ class EmptyUrlKey
         $this->progress = $progress;
         $this->productCollectionFactory = $productCollectionFactory;
         $this->attributeScopeOverriddenValueFactory = $attributeScopeOverriddenValueFactory;
+
+        $this->progressIndex = 0;
     }
 
     public function execute(): array

--- a/Checker/Catalog/Product/UrlKey/EmptyUrlKey.php
+++ b/Checker/Catalog/Product/UrlKey/EmptyUrlKey.php
@@ -9,6 +9,7 @@ use Baldwin\UrlDataIntegrityChecker\Console\Progress;
 use Baldwin\UrlDataIntegrityChecker\Util\Stores as StoresUtil;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Attribute\ScopeOverriddenValueFactory as AttributeScopeOverriddenValueFactory;
+use Magento\Catalog\Model\Product as ProductModel;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
 use Magento\Store\Model\Store;
@@ -37,6 +38,9 @@ class EmptyUrlKey
         $this->progressIndex = 0;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function execute(): array
     {
         $productData = $this->checkForEmptyUrlKeyAttributeValues();
@@ -44,6 +48,9 @@ class EmptyUrlKey
         return $productData;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     private function checkForEmptyUrlKeyAttributeValues(): array
     {
         $productsWithProblems = [];
@@ -98,6 +105,11 @@ class EmptyUrlKey
         return $productsWithProblems;
     }
 
+    /**
+     * @param ProductCollection<ProductModel> $collection
+     *
+     * @return array<array<string, mixed>>
+     */
     private function getProductsWithProblems(int $storeId, ProductCollection $collection): array
     {
         $problems = [];

--- a/Checker/Catalog/Product/UrlPath.php
+++ b/Checker/Catalog/Product/UrlPath.php
@@ -7,6 +7,7 @@ namespace Baldwin\UrlDataIntegrityChecker\Checker\Catalog\Product;
 use Baldwin\UrlDataIntegrityChecker\Util\Stores as StoresUtil;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Attribute\ScopeOverriddenValueFactory as AttributeScopeOverriddenValueFactory;
+use Magento\Catalog\Model\Product as ProductModel;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
 use Magento\Store\Model\Store;
@@ -33,6 +34,9 @@ class UrlPath
         $this->attributeScopeOverriddenValueFactory = $attributeScopeOverriddenValueFactory;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     public function execute(): array
     {
         $productData = $this->checkForNonEmptyUrlPathAttributeValues();
@@ -40,6 +44,9 @@ class UrlPath
         return $productData;
     }
 
+    /**
+     * @return array<array<string, mixed>>
+     */
     private function checkForNonEmptyUrlPathAttributeValues(): array
     {
         $productsWithProblems = [];
@@ -67,6 +74,11 @@ class UrlPath
         return $productsWithProblems;
     }
 
+    /**
+     * @param ProductCollection<ProductModel> $collection
+     *
+     * @return array<array<string, mixed>>
+     */
     private function getProductsWithProblems(int $storeId, ProductCollection $collection): array
     {
         $problems = [];

--- a/Console/CategoryResultOutput.php
+++ b/Console/CategoryResultOutput.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CategoryResultOutput
 {
+    /**
+     * @param array<array<string, mixed>> $categoryData
+     */
     public function outputResult(array $categoryData, OutputInterface $output): int
     {
         if (empty($categoryData)) {

--- a/Console/ProductResultOutput.php
+++ b/Console/ProductResultOutput.php
@@ -10,6 +10,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ProductResultOutput
 {
+    /**
+     * @param array<array<string, mixed>> $productData
+     */
     public function outputResult(array $productData, OutputInterface $output): int
     {
         if (empty($productData)) {

--- a/Console/Progress.php
+++ b/Console/Progress.php
@@ -9,10 +9,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Progress
 {
+    /** @var ProgressBar */
     private $progressBar;
+
+    /** @var OutputInterface */
     private $output;
+
     private $sizeByIndex;
     private $format;
+
+    public function __construct()
+    {
+        $this->sizeByIndex = [];
+        $this->format = '';
+    }
 
     public function setOutput(OutputInterface $output)
     {
@@ -75,7 +85,7 @@ class Progress
     private function updateMaxSteps()
     {
         if ($this->canOutput()) {
-            $newMaxStepsValue = array_sum($this->sizeByIndex);
+            $newMaxStepsValue = (int) array_sum($this->sizeByIndex);
 
             // ugly solution for the fact that the setMaxSteps method only became
             // publicly accesible in symfony/console > 4.1.0

--- a/Console/Progress.php
+++ b/Console/Progress.php
@@ -70,6 +70,9 @@ class Progress
         }
     }
 
+    /**
+     * @psalm-suppress ReservedWord
+     */
     public function finish()
     {
         if ($this->canOutput()) {

--- a/Cron/ScheduleJob.php
+++ b/Cron/ScheduleJob.php
@@ -6,6 +6,7 @@ namespace Baldwin\UrlDataIntegrityChecker\Cron;
 
 use Magento\Cron\Model\ResourceModel\Schedule\Collection as CronScheduleCollection;
 use Magento\Cron\Model\Schedule;
+use Magento\Cron\Model\Schedule as CronScheduleModel;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 use Magento\Framework\Stdlib\DateTime\TimezoneInterface;
@@ -17,6 +18,9 @@ class ScheduleJob
     private $timezone;
     private $cronScheduleCollection;
 
+    /**
+     * @param CronScheduleCollection<CronScheduleModel> $cronScheduleCollection
+     */
     public function __construct(
         ProductMetadataInterface $productMetadata,
         DateTime $dateTime,

--- a/Model/ResourceModel/Catalog/Category/UrlPathCollection.php
+++ b/Model/ResourceModel/Catalog/Category/UrlPathCollection.php
@@ -12,6 +12,7 @@ use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Data\Collection as DataCollection;
 use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
 
 class UrlPathCollection extends DataCollection implements SearchResultInterface
@@ -68,7 +69,7 @@ class UrlPathCollection extends DataCollection implements SearchResultInterface
     /**
      * @param array<string, mixed> $arguments
      */
-    public function createDataObject(array $arguments = [])
+    public function createDataObject(array $arguments = []): DataObject
     {
         $obj = $this->_entityFactory->create($this->_itemObjectClass, ['data' => $arguments]);
 

--- a/Model/ResourceModel/Catalog/Category/UrlPathCollection.php
+++ b/Model/ResourceModel/Catalog/Category/UrlPathCollection.php
@@ -27,6 +27,10 @@ class UrlPathCollection extends DataCollection implements SearchResultInterface
         $this->storage = $storage;
     }
 
+    /**
+     * @param bool $printQuery
+     * @param bool $logQuery
+     */
     public function loadData($printQuery = false, $logQuery = false)
     {
         if (!$this->isLoaded()) {
@@ -61,6 +65,9 @@ class UrlPathCollection extends DataCollection implements SearchResultInterface
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $arguments
+     */
     public function createDataObject(array $arguments = [])
     {
         $obj = $this->_entityFactory->create($this->_itemObjectClass, ['data' => $arguments]);

--- a/Model/ResourceModel/Catalog/Product/UrlKeyCollection.php
+++ b/Model/ResourceModel/Catalog/Product/UrlKeyCollection.php
@@ -27,6 +27,10 @@ class UrlKeyCollection extends DataCollection implements SearchResultInterface
         $this->storage = $storage;
     }
 
+    /**
+     * @param bool $printQuery
+     * @param bool $logQuery
+     */
     public function loadData($printQuery = false, $logQuery = false)
     {
         if (!$this->isLoaded()) {
@@ -61,6 +65,9 @@ class UrlKeyCollection extends DataCollection implements SearchResultInterface
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $arguments
+     */
     public function createDataObject(array $arguments = [])
     {
         $obj = $this->_entityFactory->create($this->_itemObjectClass, ['data' => $arguments]);

--- a/Model/ResourceModel/Catalog/Product/UrlKeyCollection.php
+++ b/Model/ResourceModel/Catalog/Product/UrlKeyCollection.php
@@ -12,6 +12,7 @@ use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Data\Collection as DataCollection;
 use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
 
 class UrlKeyCollection extends DataCollection implements SearchResultInterface
@@ -68,7 +69,7 @@ class UrlKeyCollection extends DataCollection implements SearchResultInterface
     /**
      * @param array<string, mixed> $arguments
      */
-    public function createDataObject(array $arguments = [])
+    public function createDataObject(array $arguments = []): DataObject
     {
         $obj = $this->_entityFactory->create($this->_itemObjectClass, ['data' => $arguments]);
 

--- a/Model/ResourceModel/Catalog/Product/UrlPathCollection.php
+++ b/Model/ResourceModel/Catalog/Product/UrlPathCollection.php
@@ -12,6 +12,7 @@ use Magento\Framework\Api\Search\SearchResultInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Data\Collection as DataCollection;
 use Magento\Framework\Data\Collection\EntityFactoryInterface;
+use Magento\Framework\DataObject;
 use Magento\Framework\Exception\LocalizedException;
 
 class UrlPathCollection extends DataCollection implements SearchResultInterface
@@ -68,7 +69,7 @@ class UrlPathCollection extends DataCollection implements SearchResultInterface
     /**
      * @param array<string, mixed> $arguments
      */
-    public function createDataObject(array $arguments = [])
+    public function createDataObject(array $arguments = []): DataObject
     {
         $obj = $this->_entityFactory->create($this->_itemObjectClass, ['data' => $arguments]);
 

--- a/Model/ResourceModel/Catalog/Product/UrlPathCollection.php
+++ b/Model/ResourceModel/Catalog/Product/UrlPathCollection.php
@@ -27,6 +27,10 @@ class UrlPathCollection extends DataCollection implements SearchResultInterface
         $this->storage = $storage;
     }
 
+    /**
+     * @param bool $printQuery
+     * @param bool $logQuery
+     */
     public function loadData($printQuery = false, $logQuery = false)
     {
         if (!$this->isLoaded()) {
@@ -61,6 +65,9 @@ class UrlPathCollection extends DataCollection implements SearchResultInterface
         return $this;
     }
 
+    /**
+     * @param array<string, mixed> $arguments
+     */
     public function createDataObject(array $arguments = [])
     {
         $obj = $this->_entityFactory->create($this->_itemObjectClass, ['data' => $arguments]);

--- a/Storage/Meta.php
+++ b/Storage/Meta.php
@@ -101,6 +101,9 @@ class Meta
         return false;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getData(string $storageIdentifier): array
     {
         $storageIdentifier .= self::STORAGE_SUFFIX;

--- a/Storage/Meta.php
+++ b/Storage/Meta.php
@@ -111,7 +111,7 @@ class Meta
         return $this->storage->read($storageIdentifier);
     }
 
-    public function clearStatus(string $storageIdentifier)
+    public function clearStatus(string $storageIdentifier): bool
     {
         $storageIdentifier .= self::STORAGE_SUFFIX;
 

--- a/Storage/StorageInterface.php
+++ b/Storage/StorageInterface.php
@@ -6,9 +6,18 @@ namespace Baldwin\UrlDataIntegrityChecker\Storage;
 
 interface StorageInterface
 {
+    /**
+     * @param array<string, mixed> $data
+     */
     public function write(string $identifier, array $data): bool;
 
+    /**
+     * @return array<string, mixed>
+     */
     public function read(string $identifier): array;
 
+    /**
+     * @param array<string, mixed> $data
+     */
     public function update(string $identifier, array $data): bool;
 }

--- a/Test/Checker/Catalog/Product/UrlKey/DuplicateUrlKeyTest.php
+++ b/Test/Checker/Catalog/Product/UrlKey/DuplicateUrlKeyTest.php
@@ -18,6 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class DuplicateUrlKeyTest extends TestCase
 {
+    /** @var ObjectManagerHelper */
     private $objectManagerHelper;
 
     protected function setUp()
@@ -28,7 +29,7 @@ class DuplicateUrlKeyTest extends TestCase
     /**
      * @dataProvider duplicatedProductUrlKeyValuesDataProvider
      */
-    public function testDuplicatedProductUrlKeyValues($dbData, $expectedResults)
+    public function testDuplicatedProductUrlKeyValues(array $dbData, array $expectedResults)
     {
         $dbData = array_map(function ($productData) {
             return new DataObject($productData);

--- a/Test/Checker/Catalog/Product/UrlKey/DuplicateUrlKeyTest.php
+++ b/Test/Checker/Catalog/Product/UrlKey/DuplicateUrlKeyTest.php
@@ -28,6 +28,9 @@ class DuplicateUrlKeyTest extends TestCase
 
     /**
      * @dataProvider duplicatedProductUrlKeyValuesDataProvider
+     *
+     * @param array<array<string, mixed>> $dbData
+     * @param array<array<string, mixed>> $expectedResults
      */
     public function testDuplicatedProductUrlKeyValues(array $dbData, array $expectedResults)
     {

--- a/Test/Checker/Catalog/Product/UrlKey/DuplicateUrlKeyTest.php
+++ b/Test/Checker/Catalog/Product/UrlKey/DuplicateUrlKeyTest.php
@@ -134,7 +134,10 @@ class DuplicateUrlKeyTest extends TestCase
         $this->assertEquals($expectedResults, $results);
     }
 
-    public function duplicatedProductUrlKeyValuesDataProvider()
+    /**
+     * @return array<array<array<array<string, mixed>>>>
+     */
+    public function duplicatedProductUrlKeyValuesDataProvider(): array
     {
         return [
             // 0. two products having different url key, is ok!

--- a/Test/Storage/CacheStorageTest.php
+++ b/Test/Storage/CacheStorageTest.php
@@ -85,6 +85,9 @@ class CacheStorageTest extends TestCase
         $this->assertEquals($expectedData, $cacheStorage->read($identifier));
     }
 
+    /**
+     * @param array<string, string> $data
+     */
     private function jsonEncode(array $data): string
     {
         $data = json_encode($data, JSON_UNESCAPED_UNICODE);

--- a/Updater/Catalog/Category/UrlPath.php
+++ b/Updater/Catalog/Category/UrlPath.php
@@ -26,7 +26,7 @@ class UrlPath
     }
 
     /**
-     * @return array<string>
+     * @return array<array<string, mixed>>
      */
     public function refresh(string $initiator): array
     {

--- a/Updater/Catalog/Category/UrlPath.php
+++ b/Updater/Catalog/Category/UrlPath.php
@@ -25,6 +25,9 @@ class UrlPath
         $this->metaStorage = $metaStorage;
     }
 
+    /**
+     * @return array<string>
+     */
     public function refresh(string $initiator): array
     {
         $storageIdentifier = UrlPathChecker::STORAGE_IDENTIFIER;

--- a/Updater/Catalog/Product/UrlKey.php
+++ b/Updater/Catalog/Product/UrlKey.php
@@ -26,7 +26,7 @@ class UrlKey
     }
 
     /**
-     * @return array<string>
+     * @return array<array<string, mixed>>
      */
     public function refresh(string $initiator): array
     {

--- a/Updater/Catalog/Product/UrlKey.php
+++ b/Updater/Catalog/Product/UrlKey.php
@@ -25,6 +25,9 @@ class UrlKey
         $this->metaStorage = $metaStorage;
     }
 
+    /**
+     * @return array<string>
+     */
     public function refresh(string $initiator): array
     {
         $storageIdentifier = UrlKeyChecker::STORAGE_IDENTIFIER;

--- a/Updater/Catalog/Product/UrlPath.php
+++ b/Updater/Catalog/Product/UrlPath.php
@@ -26,7 +26,7 @@ class UrlPath
     }
 
     /**
-     * @return array<string>
+     * @return array<array<string, mixed>>
      */
     public function refresh(string $initiator): array
     {

--- a/Updater/Catalog/Product/UrlPath.php
+++ b/Updater/Catalog/Product/UrlPath.php
@@ -25,6 +25,9 @@ class UrlPath
         $this->metaStorage = $metaStorage;
     }
 
+    /**
+     * @return array<string>
+     */
     public function refresh(string $initiator): array
     {
         $storageIdentifier = UrlPathChecker::STORAGE_IDENTIFIER;

--- a/Util/Stores.php
+++ b/Util/Stores.php
@@ -16,6 +16,9 @@ class Stores
         $this->storeRepository = $storeRepository;
     }
 
+    /**
+     * @return array<int>
+     */
     public function getAllStoreIds(): array
     {
         $storeIds = [];

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/console": "^2.5 || ^3.0 || ^4.0"
     },
     "require-dev": {
-        "bitexpert/phpstan-magento": "dev-master",
+        "bitexpert/phpstan-magento": "^0.1.0",
         "ergebnis/composer-normalize": "^2.2",
         "friendsofphp/php-cs-fixer": "^2.15",
         "magento/magento-coding-standard": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "magento/magento-coding-standard": "^5.0",
         "phpcompatibility/php-compatibility": "^9.2",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.11.12",
+        "phpstan/phpstan": "^0.12.0",
         "phpunit/phpunit": "^7.5",
         "vimeo/psalm": "^3.9"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -5258,12 +5258,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/bitExpert/phpstan-magento.git",
-                "reference": "ebf064925ae2f4a884d5646f30e698b293d128d2"
+                "reference": "76410fc2d56f833728d3cd3978eb47e17f152f3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bitExpert/phpstan-magento/zipball/ebf064925ae2f4a884d5646f30e698b293d128d2",
-                "reference": "ebf064925ae2f4a884d5646f30e698b293d128d2",
+                "url": "https://api.github.com/repos/bitExpert/phpstan-magento/zipball/76410fc2d56f833728d3cd3978eb47e17f152f3a",
+                "reference": "76410fc2d56f833728d3cd3978eb47e17f152f3a",
                 "shasum": ""
             },
             "require": {
@@ -5307,7 +5307,7 @@
                 }
             ],
             "description": "PHPStan Magento Extension",
-            "time": "2020-04-07T07:18:48+00:00"
+            "time": "2020-04-08T19:45:20+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a3682037b6c73ebe1288efd9e00bc096",
+    "content-hash": "c664ae54fde63cc0ad93be7fa24ddd51",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -3007,16 +3007,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801"
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/446d54b4cb6bf489fc9d75f55843658e6f25d801",
-                "reference": "446d54b4cb6bf489fc9d75f55843658e6f25d801",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
                 "shasum": ""
             },
             "require": {
@@ -3050,7 +3050,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2019-11-01T11:05:21+00:00"
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -3308,16 +3308,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.5",
+            "version": "v4.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ea69c129aed9fdeca781d4b77eb20b62cf5d5357"
+                "reference": "5729f943f9854c5781984ed4907bbb817735776b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ea69c129aed9fdeca781d4b77eb20b62cf5d5357",
-                "reference": "ea69c129aed9fdeca781d4b77eb20b62cf5d5357",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5729f943f9854c5781984ed4907bbb817735776b",
+                "reference": "5729f943f9854c5781984ed4907bbb817735776b",
                 "shasum": ""
             },
             "require": {
@@ -3353,7 +3353,21 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-02-14T07:42:58+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-27T16:54:36+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5244,24 +5258,25 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/bitExpert/phpstan-magento.git",
-                "reference": "20572c1325b4da63d4922ea21e35e7a3680d35b0"
+                "reference": "ebf064925ae2f4a884d5646f30e698b293d128d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bitExpert/phpstan-magento/zipball/20572c1325b4da63d4922ea21e35e7a3680d35b0",
-                "reference": "20572c1325b4da63d4922ea21e35e7a3680d35b0",
+                "url": "https://api.github.com/repos/bitExpert/phpstan-magento/zipball/ebf064925ae2f4a884d5646f30e698b293d128d2",
+                "reference": "ebf064925ae2f4a884d5646f30e698b293d128d2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.0",
-                "phpstan/phpstan": "^0.11.6"
+                "php": "^7.2.0",
+                "phpstan/phpstan": "^0.12.18"
             },
             "require-dev": {
                 "bitexpert/phing-securitychecker": "^0.4.0",
-                "captainhook/captainhook": "^4.0",
-                "captainhook/plugin-composer": "^4.0",
+                "captainhook/captainhook": "^5.1.2",
+                "captainhook/plugin-composer": "^5.1.3",
+                "nikic/php-parser": "^4.3",
                 "phing/phing": "^2.16",
-                "phpunit/phpunit": "^7.5",
+                "phpunit/phpunit": "^8.5.3",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "type": "phpstan-extension",
@@ -5292,7 +5307,7 @@
                 }
             ],
             "description": "PHPStan Magento Extension",
-            "time": "2020-02-16T21:28:24+00:00"
+            "time": "2020-04-07T07:18:48+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -5839,57 +5854,6 @@
             "time": "2019-11-25T22:10:32+00:00"
         },
         {
-            "name": "jean85/pretty-package-versions",
-            "version": "1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Jean85/pretty-package-versions.git",
-                "reference": "75c7effcf3f77501d0e0caa75111aff4daa0dd48"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/75c7effcf3f77501d0e0caa75111aff4daa0dd48",
-                "reference": "75c7effcf3f77501d0e0caa75111aff4daa0dd48",
-                "shasum": ""
-            },
-            "require": {
-                "ocramius/package-versions": "^1.2.0",
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Jean85\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alessandro Lai",
-                    "email": "alessandro.lai85@gmail.com"
-                }
-            ],
-            "description": "A wrapper for ocramius/package-versions to get pretty versions strings",
-            "keywords": [
-                "composer",
-                "package",
-                "release",
-                "versions"
-            ],
-            "time": "2018-06-13T13:22:40+00:00"
-        },
-        {
             "name": "localheinz/diff",
             "version": "1.0.1",
             "source": {
@@ -6072,535 +6036,6 @@
             ],
             "description": "Map nested JSON structures onto PHP classes",
             "time": "2019-08-15T19:41:25+00:00"
-        },
-        {
-            "name": "nette/bootstrap",
-            "version": "v3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/bootstrap.git",
-                "reference": "b45a1e33b6a44beb307756522396551e5a9ff249"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/bootstrap/zipball/b45a1e33b6a44beb307756522396551e5a9ff249",
-                "reference": "b45a1e33b6a44beb307756522396551e5a9ff249",
-                "shasum": ""
-            },
-            "require": {
-                "nette/di": "^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "tracy/tracy": "<2.6"
-            },
-            "require-dev": {
-                "latte/latte": "^2.2",
-                "nette/application": "^3.0",
-                "nette/caching": "^3.0",
-                "nette/database": "^3.0",
-                "nette/forms": "^3.0",
-                "nette/http": "^3.0",
-                "nette/mail": "^3.0",
-                "nette/robot-loader": "^3.0",
-                "nette/safe-stream": "^2.2",
-                "nette/security": "^3.0",
-                "nette/tester": "^2.0",
-                "tracy/tracy": "^2.6"
-            },
-            "suggest": {
-                "nette/robot-loader": "to use Configurator::createRobotLoader()",
-                "tracy/tracy": "to use Configurator::enableTracy()"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🅱 Nette Bootstrap: the simple way to configure and bootstrap your Nette application.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "bootstrapping",
-                "configurator",
-                "nette"
-            ],
-            "time": "2019-09-30T08:19:38+00:00"
-        },
-        {
-            "name": "nette/di",
-            "version": "v3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/di.git",
-                "reference": "77d69061cbf8f9cfb7363dd983136f51213d3e41"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/di/zipball/77d69061cbf8f9cfb7363dd983136f51213d3e41",
-                "reference": "77d69061cbf8f9cfb7363dd983136f51213d3e41",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/neon": "^3.0",
-                "nette/php-generator": "^3.3.3",
-                "nette/robot-loader": "^3.2",
-                "nette/schema": "^1.0",
-                "nette/utils": "^3.1",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "nette/bootstrap": "<3.0"
-            },
-            "require-dev": {
-                "nette/tester": "^2.2",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "💎 Nette Dependency Injection Container: Flexible, compiled and full-featured DIC with perfectly usable autowiring and support for all new PHP 7.1 features.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "compiled",
-                "di",
-                "dic",
-                "factory",
-                "ioc",
-                "nette",
-                "static"
-            ],
-            "time": "2020-01-20T12:14:54+00:00"
-        },
-        {
-            "name": "nette/finder",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/finder.git",
-                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/finder/zipball/4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
-                "reference": "4ad2c298eb8c687dd0e74ae84206a4186eeaed50",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^2.4 || ^3.0",
-                "php": ">=7.1"
-            },
-            "conflict": {
-                "nette/nette": "<2.2"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.5-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "filesystem",
-                "glob",
-                "iterator",
-                "nette"
-            ],
-            "time": "2020-01-03T20:35:40+00:00"
-        },
-        {
-            "name": "nette/neon",
-            "version": "v3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/neon.git",
-                "reference": "bf658bafcf56e36cfa0922f4866869927672cf2c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/neon/zipball/bf658bafcf56e36cfa0922f4866869927672cf2c",
-                "reference": "bf658bafcf56e36cfa0922f4866869927672cf2c",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "ext-json": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
-            "homepage": "https://ne-on.org",
-            "keywords": [
-                "export",
-                "import",
-                "neon",
-                "nette",
-                "yaml"
-            ],
-            "time": "2020-02-12T11:15:48+00:00"
-        },
-        {
-            "name": "nette/php-generator",
-            "version": "v3.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/php-generator.git",
-                "reference": "8fe7e699dca7db186f56d75800cb1ec32e39c856"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/8fe7e699dca7db186f56d75800cb1ec32e39c856",
-                "reference": "8fe7e699dca7db186f56d75800cb1ec32e39c856",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^2.4.2 || ^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.4 features.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "code",
-                "nette",
-                "php",
-                "scaffolding"
-            ],
-            "time": "2020-02-09T14:39:09+00:00"
-        },
-        {
-            "name": "nette/robot-loader",
-            "version": "v3.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/robot-loader.git",
-                "reference": "38e8a270567a4ad9fe716b40fcda5a6580afa3c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/robot-loader/zipball/38e8a270567a4ad9fe716b40fcda5a6580afa3c0",
-                "reference": "38e8a270567a4ad9fe716b40fcda5a6580afa3c0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "nette/finder": "^2.5 || ^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🍀 Nette RobotLoader: high performance and comfortable autoloader that will search and autoload classes within your application.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "autoload",
-                "class",
-                "interface",
-                "nette",
-                "trait"
-            ],
-            "time": "2020-02-20T22:17:50+00:00"
-        },
-        {
-            "name": "nette/schema",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/schema.git",
-                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/schema/zipball/febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
-                "reference": "febf71fb4052c824046f5a33f4f769a6e7fa0cb4",
-                "shasum": ""
-            },
-            "require": {
-                "nette/utils": "^3.1",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "^2.2",
-                "phpstan/phpstan-nette": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "📐 Nette Schema: validating data structures against a given Schema.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "config",
-                "nette"
-            ],
-            "time": "2020-01-06T22:52:48+00:00"
-        },
-        {
-            "name": "nette/utils",
-            "version": "v3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nette/utils.git",
-                "reference": "2c17d16d8887579ae1c0898ff94a3668997fd3eb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/2c17d16d8887579ae1c0898ff94a3668997fd3eb",
-                "reference": "2c17d16d8887579ae1c0898ff94a3668997fd3eb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/tester": "~2.0",
-                "phpstan/phpstan": "^0.12",
-                "tracy/tracy": "^2.3"
-            },
-            "suggest": {
-                "ext-gd": "to use Image",
-                "ext-iconv": "to use Strings::webalize() and toAscii()",
-                "ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
-                "ext-json": "to use Nette\\Utils\\Json",
-                "ext-mbstring": "to use Strings::lower() etc...",
-                "ext-tokenizer": "to use Nette\\Utils\\Reflection::getUseStatements()",
-                "ext-xml": "to use Strings::length() etc. when mbstring is not available"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0-only",
-                "GPL-3.0-only"
-            ],
-            "authors": [
-                {
-                    "name": "David Grudl",
-                    "homepage": "https://davidgrudl.com"
-                },
-                {
-                    "name": "Nette Community",
-                    "homepage": "https://nette.org/contributors"
-                }
-            ],
-            "description": "🛠 Nette Utils: lightweight utilities for string & array manipulation, image handling, safe JSON encoding/decoding, validation, slug or strong password generating etc.",
-            "homepage": "https://nette.org",
-            "keywords": [
-                "array",
-                "core",
-                "datetime",
-                "images",
-                "json",
-                "nette",
-                "paginator",
-                "password",
-                "slugify",
-                "string",
-                "unicode",
-                "utf-8",
-                "utility",
-                "validation"
-            ],
-            "time": "2020-02-09T14:10:55+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -7268,126 +6703,57 @@
             "time": "2019-10-18T17:09:48+00:00"
         },
         {
-            "name": "phpstan/phpdoc-parser",
-            "version": "0.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/8c4ef2aefd9788238897b678a985e1d5c8df6db4",
-                "reference": "8c4ef2aefd9788238897b678a985e1d5c8df6db4",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7.1"
-            },
-            "require-dev": {
-                "consistence/coding-standard": "^3.5",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan": "^0.10",
-                "phpunit/phpunit": "^6.3",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2",
-                "symfony/process": "^3.4 || ^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PHPStan\\PhpDocParser\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2019-06-07T19:13:52+00:00"
-        },
-        {
             "name": "phpstan/phpstan",
-            "version": "0.11.19",
+            "version": "0.12.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7"
+                "reference": "1ce27fe29c8660a27926127d350d53d80c4d4286"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/63cc502f6957b7f74efbac444b4cf219dcadffd7",
-                "reference": "63cc502f6957b7f74efbac444b4cf219dcadffd7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1ce27fe29c8660a27926127d350d53d80c4d4286",
+                "reference": "1ce27fe29c8660a27926127d350d53d80c4d4286",
                 "shasum": ""
             },
             "require": {
-                "composer/xdebug-handler": "^1.3.0",
-                "jean85/pretty-package-versions": "^1.0.3",
-                "nette/bootstrap": "^2.4 || ^3.0",
-                "nette/di": "^2.4.7 || ^3.0",
-                "nette/neon": "^2.4.3 || ^3.0",
-                "nette/robot-loader": "^3.0.1",
-                "nette/schema": "^1.0",
-                "nette/utils": "^2.4.5 || ^3.0",
-                "nikic/php-parser": "^4.2.3",
-                "php": "~7.1",
-                "phpstan/phpdoc-parser": "^0.3.5",
-                "symfony/console": "~3.2 || ~4.0",
-                "symfony/finder": "~3.2 || ~4.0"
-            },
-            "conflict": {
-                "symfony/console": "3.4.16 || 4.1.5"
-            },
-            "require-dev": {
-                "brianium/paratest": "^2.0 || ^3.0",
-                "consistence/coding-standard": "^3.5",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-                "ext-intl": "*",
-                "ext-mysqli": "*",
-                "ext-simplexml": "*",
-                "ext-soap": "*",
-                "ext-zip": "*",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "localheinz/composer-normalize": "^1.1.0",
-                "phing/phing": "^2.16.0",
-                "phpstan/phpstan-deprecation-rules": "^0.11",
-                "phpstan/phpstan-php-parser": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
-                "phpunit/phpunit": "^7.5.14 || ^8.0",
-                "slevomat/coding-standard": "^4.7.2",
-                "squizlabs/php_codesniffer": "^3.3.2"
+                "php": "^7.1"
             },
             "bin": [
-                "bin/phpstan"
+                "phpstan",
+                "phpstan.phar"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.11-dev"
+                    "dev-master": "0.12-dev"
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "PHPStan\\": [
-                        "src/"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
-            "time": "2019-10-22T20:20:22+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-03-22T16:51:47+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -9085,5 +8451,6 @@
     "platform": {
         "php": "~7.0.0 || ~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c664ae54fde63cc0ad93be7fa24ddd51",
+    "content-hash": "729e77045ae20e9ef14d9a44eeca14a6",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -5254,19 +5254,20 @@
         },
         {
             "name": "bitexpert/phpstan-magento",
-            "version": "dev-master",
+            "version": "v0.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bitExpert/phpstan-magento.git",
-                "reference": "76410fc2d56f833728d3cd3978eb47e17f152f3a"
+                "reference": "a49a5c0fc17698b5a07d133f47fd9d4fffbce893"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bitExpert/phpstan-magento/zipball/76410fc2d56f833728d3cd3978eb47e17f152f3a",
-                "reference": "76410fc2d56f833728d3cd3978eb47e17f152f3a",
+                "url": "https://api.github.com/repos/bitExpert/phpstan-magento/zipball/a49a5c0fc17698b5a07d133f47fd9d4fffbce893",
+                "reference": "a49a5c0fc17698b5a07d133f47fd9d4fffbce893",
                 "shasum": ""
             },
             "require": {
+                "nette/neon": "^3.1",
                 "php": "^7.2.0",
                 "phpstan/phpstan": "^0.12.18"
             },
@@ -5274,6 +5275,7 @@
                 "bitexpert/phing-securitychecker": "^0.4.0",
                 "captainhook/captainhook": "^5.1.2",
                 "captainhook/plugin-composer": "^5.1.3",
+                "mikey179/vfsstream": "^1.6",
                 "nikic/php-parser": "^4.3",
                 "phing/phing": "^2.16",
                 "phpunit/phpunit": "^8.5.3",
@@ -5288,9 +5290,6 @@
                 }
             },
             "autoload": {
-                "files": [
-                    "registration.php"
-                ],
                 "psr-4": {
                     "bitExpert\\PHPStan\\": "src/bitExpert/PHPStan"
                 }
@@ -5307,7 +5306,7 @@
                 }
             ],
             "description": "PHPStan Magento Extension",
-            "time": "2020-04-08T19:45:20+00:00"
+            "time": "2020-04-18T12:12:08+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -6038,6 +6037,68 @@
             "time": "2019-08-15T19:41:25+00:00"
         },
         {
+            "name": "nette/neon",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nette/neon.git",
+                "reference": "3c3dcbc6bf6c80dc97b1fc4ba9a22ae67930fc0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nette/neon/zipball/3c3dcbc6bf6c80dc97b1fc4ba9a22ae67930fc0e",
+                "reference": "3c3dcbc6bf6c80dc97b1fc4ba9a22ae67930fc0e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.0",
+                "phpstan/phpstan": "^0.12",
+                "tracy/tracy": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0-only",
+                "GPL-3.0-only"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                },
+                {
+                    "name": "Nette Community",
+                    "homepage": "https://nette.org/contributors"
+                }
+            ],
+            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "homepage": "https://ne-on.org",
+            "keywords": [
+                "export",
+                "import",
+                "neon",
+                "nette",
+                "yaml"
+            ],
+            "time": "2020-03-04T11:47:04+00:00"
+        },
+        {
             "name": "nikic/php-parser",
             "version": "v4.3.0",
             "source": {
@@ -6660,20 +6721,20 @@
         },
         {
             "name": "phpstan/extension-installer",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/extension-installer.git",
-                "reference": "295656793c53b5eb73a38486032ad1bd650264bc"
+                "reference": "2e041def501d661b806f50000c8a4dccbd4907b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/295656793c53b5eb73a38486032ad1bd650264bc",
-                "reference": "295656793c53b5eb73a38486032ad1bd650264bc",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/2e041def501d661b806f50000c8a4dccbd4907b4",
+                "reference": "2e041def501d661b806f50000c8a4dccbd4907b4",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1",
+                "composer-plugin-api": "^1.1 || ^2.0",
                 "php": "^7.1",
                 "phpstan/phpstan": ">=0.11.6"
             },
@@ -6681,6 +6742,7 @@
                 "composer/composer": "^1.8",
                 "consistence/coding-standard": "^3.8",
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
                 "jakub-onderka/php-parallel-lint": "^1.0",
                 "phing/phing": "^2.16",
                 "phpstan/phpstan-strict-rules": "^0.11",
@@ -6700,7 +6762,7 @@
                 "MIT"
             ],
             "description": "Composer plugin for automatic installation of PHPStan extensions",
-            "time": "2019-10-18T17:09:48+00:00"
+            "time": "2020-03-31T16:00:42+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -8443,9 +8505,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "bitexpert/phpstan-magento": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -6766,20 +6766,23 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.18",
+            "version": "0.12.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "1ce27fe29c8660a27926127d350d53d80c4d4286"
+                "reference": "054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1ce27fe29c8660a27926127d350d53d80c4d4286",
-                "reference": "1ce27fe29c8660a27926127d350d53d80c4d4286",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d",
+                "reference": "054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
             },
             "bin": [
                 "phpstan",
@@ -6815,7 +6818,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-03-22T16:51:47+00:00"
+            "time": "2020-04-19T20:35:10+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,12 @@
 parameters:
     level: 7
     inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: false
     paths:
         - .
+    autoload_files:
+        - vendor/bitexpert/phpstan-magento/autoload.php
     excludes_analyse:
         - %currentWorkingDirectory%/vendor/*
+    ignoreErrors:
+        - '/ has no return typehint specified./'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,6 @@
 parameters:
-    level: 7
+    level: 8
     inferPrivatePropertyTypeFromConstructor: true
-    checkMissingIterableValueType: false
     paths:
         - .
     autoload_files:


### PR DESCRIPTION
- Updated phpstan from 0.11.19 to 0.12.19, including a bunch of its dependencies.
- Increased level from 7 to 8
- Ignored new check for return types, so we do not enforce adding them to all methods (returning `void` isn't compatible with PHP 7.0 and adding return types on certain public functions does not work in Magento 2.1.x)
- Fixed all new errors phpstan found