### PR TITLE
git hub actions

### DIFF
--- a/.github/workflows/phpcompatibility.yml
+++ b/.github/workflows/phpcompatibility.yml
@@ -1,0 +1,9 @@
+name: PHPCompatibility
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: 7.0-7.1
+      run: docker run --rm -v $PWD:/code domw/phpcompatibility phpcs --standard=PHPCompatibility --runtime-set testVersion 7.0-7.1 --colors --ignore=./Test/ ./

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,0 +1,9 @@
+name: phpcs
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Magento 2 Ruleset
+      run: docker run --rm -v $PWD:/code domw/phpcs phpcs --colors --standard=Magento2 ./

--- a/.github/workflows/phpcsfixer.yml
+++ b/.github/workflows/phpcsfixer.yml
@@ -1,0 +1,9 @@
+name: php-cs-fixer
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: PHP CS Fixer
+      run: docker run --rm -v $PWD:/code domw/php-cs-fixer php-cs-fixer fix --dry-run --diff --stop-on-violation --allow-risky=yes ./

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,15 @@
+name: PHPStan
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: MilesChou/composer-action@master
+      with:
+        args: config http-basic.repo.magento.com 7bdd660a63609d2af9fcbc033a9eae8d 77c0cedb4871620c63acbd82aeb92f38
+    - uses: MilesChou/composer-action@master
+      with:
+        args: install --prefer-dist --ignore-platform-reqs
+    - name: PHPStan
+      run: docker run --rm -v $PWD:/code domw/phpstan phpstan analyze ./

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,15 @@
+name: PHPUnit
+on: ["push", "pull_request"]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: MilesChou/composer-action@master
+      with:
+        args: config http-basic.repo.magento.com 7bdd660a63609d2af9fcbc033a9eae8d 77c0cedb4871620c63acbd82aeb92f38
+    - uses: MilesChou/composer-action@master
+      with:
+        args: install --prefer-dist --ignore-platform-reqs 
+    - name: PHPUnit
+      run: vendor/bin/phpunit -c Test/phpunit.xml Test/

--- a/.github/workflows/xmllint.yml
+++ b/.github/workflows/xmllint.yml
@@ -1,0 +1,21 @@
+name: xmllint
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: MilesChou/composer-action@master
+      with:
+        args: config http-basic.repo.magento.com 7bdd660a63609d2af9fcbc033a9eae8d 77c0cedb4871620c63acbd82aeb92f38
+    - uses: MilesChou/composer-action@master
+      with:
+        args: install --prefer-dist --ignore-platform-reqs    
+    - name: XML Lint
+      run: |
+       docker run --rm -v $PWD:/code domw/xmllint --noout ./etc/adminhtml/menu.xml --schema ./vendor/magento/module-backend/etc/menu.xsd
+       docker run --rm -v $PWD:/code domw/xmllint --noout ./etc/adminhtml/routes.xml --schema ./vendor/magento/framework/App/etc/routes.xsd
+       docker run --rm -v $PWD:/code domw/xmllint --noout ./etc/acl.xml --schema ./vendor/magento/framework/Acl/etc/acl.xsd
+       docker run --rm -v $PWD:/code domw/xmllint --noout ./etc/cron_groups.xml --schema ./vendor/magento/module-cron/etc/cron_groups.xsd
+       docker run --rm -v $PWD:/code domw/xmllint --noout ./etc/crontab.xml --schema ./vendor/magento/module-cron/etc/crontab.xsd
+       docker run --rm -v $PWD:/code domw/xmllint --noout ./etc/module.xml --schema ./vendor/magento/framework/Module/etc/module.xsd

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,20 +1,11 @@
 parameters:
     level: max
-    inferPrivatePropertyTypeFromConstructor: true
-    paths:
-        - .
-    bootstrapFiles:
-        - vendor/bitexpert/phpstan-magento/autoload.php
     excludes_analyse:
-        - %currentWorkingDirectory%/vendor/*
+        - 'vendor'
     ignoreErrors:
-        - '/ has no return typehint specified./'
-
-        - message: '/Use service contracts to persist entities in favour of Magento\\Cron\\Model\\Schedule\:\:save\(\) method/'
-          path: Cron/ScheduleJob.php
-
-        - message: '/Call to deprecated method save\(\) of class Magento\\Framework\\Model\\AbstractModel/'
-          path: Cron/ScheduleJob.php
-
-        - message: '/Parameter \#1 \$autoload_function of function spl_autoload_register expects callable\(string\)\: void, array\(Magento\\Framework\\TestFramework\\Unit\\Autoloader\\GeneratedClassesAutoloader/'
-          path: Test/bootstrap.php
+        - '#typehint#'
+        - '#Factory#'
+        - '#Use service contracts to persist entities#'
+        - '#Call to deprecated method save#'
+        - '#Parameter \#1 \$autoload_function of function spl_autoload_register#'
+    reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
docker container based github actions to test code instead of makefile which for example relies on components being available locally. Plus get added automatic code scan on any PRs

key is in action so publicly visible but no reason couldn't utilise github secrets for key

this is more a demo of what can be done

Results look like this:

https://github.com/DominicWatts/magento2-module-url-data-integrity-checker/actions

You don't _have_ to use container approach e.g. https://github.com/DominicWatts/Menu/blob/master/.github/workflows/standards.yml

However the reason I use container based approach is it's easier to switch php version and also for phpstan in particular not to throw false positives if components from M2 required modules are used : php_intl - e.g. IntlDateFormatter not found etc.

https://github.com/DominicWatts/PHPStan

But certainly container based unit tests are difficult