### PR TITLE
Remove unnecessary setup version

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Baldwin_UrlDataIntegrityChecker" setup_version="1.0.0">
+    <module name="Baldwin_UrlDataIntegrityChecker">
         <sequence>
             <module name="Magento_Backend"/>
             <module name="Magento_Catalog"/>


### PR DESCRIPTION
If I am not mistaken, this module does not rely on any setup / upgrade scripts. Hence, there is no need for a setup version. Having it still in the config means that we cannot have a zero-downtime-deployment when deploying this module (since `bin/magento setup:db:status` will say updates are necessary).